### PR TITLE
Refactor example to have all hub messages have serializers

### DIFF
--- a/example/chat-app/ChatApp.GrainInterfaces/Model/ChatHubModels.cs
+++ b/example/chat-app/ChatApp.GrainInterfaces/Model/ChatHubModels.cs
@@ -1,5 +1,7 @@
-namespace ChatApp.Server.Model;
+namespace ChatApp.GrainInterfaces.Model;
 
+[GenerateSerializer]
 public record JoinChatRequest(string ChatName);
 
+[GenerateSerializer]
 public record SendMessageRequest(string ChatName, string SenderName, string Message);

--- a/example/chat-app/ChatApp.Server/Clients/IChatClient.cs
+++ b/example/chat-app/ChatApp.Server/Clients/IChatClient.cs
@@ -1,4 +1,4 @@
-using ChatApp.Server.Model;
+using ChatApp.GrainInterfaces.Model;
 
 namespace ChatApp.Server.Clients;
 

--- a/example/chat-app/ChatApp.Server/Hubs/ChatHub.cs
+++ b/example/chat-app/ChatApp.Server/Hubs/ChatHub.cs
@@ -2,7 +2,6 @@ using System.Text.RegularExpressions;
 using ChatApp.GrainInterfaces;
 using ChatApp.GrainInterfaces.Model;
 using ChatApp.Server.Clients;
-using ChatApp.Server.Model;
 using Microsoft.AspNetCore.SignalR;
 
 namespace ChatApp.Server.Hubs;

--- a/src/OrgnalR.OrleansSilo/Extensions.cs
+++ b/src/OrgnalR.OrleansSilo/Extensions.cs
@@ -77,6 +77,7 @@ namespace OrgnalR.Silo
                     configure?.Invoke(conf);
                     services.Add(new ServiceDescriptor(typeof(OrgnalRSiloConfig), conf));
 
+                    services.AddSingleton<IGrainFactoryProvider, GrainFactoryProvider>();
                     services.AddSingleton<IActorProviderFactory, GrainActorProviderFactory>();
                 }
             );


### PR DESCRIPTION
This allows us to have a working example, however I don't think it's great forcing consumers to add serialization attributes to all their classes