### PR TITLE
Use the orleans built in serializer to serialize messages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
-        <Version>2.0.0-prerelease2</Version>
+        <Version>2.0.0-prerelease3</Version>
         <Authors>Liam Morrow</Authors>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <IncludeSymbols>true</IncludeSymbols>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,24 @@ class Startup {
 }
 ```
 
-That's it on the SignalR side. There is no difference between a production and a development environment for the SignalR client.
+Next, Orleans needs to know how to serialize your Hub Requests and Responses.
+The easiest way to achieve this is to annotate your request/response classes with the `GenerateSerializer` attribute, as you would with any of your normal grain models.
+
+Example:
+
+```c#
+[GenerateSerializer]
+public record SendMessageRequest(string ChatName, string SenderName, string Message);
+
+// Usage in a hub
+public class ChatHub : Hub<IChatClient>
+{
+
+    public async Task SendMessage(SendMessageRequest request)
+}
+```
+
+Please see the [example directory](example) for a fully working solution.
 
 #### Orleans Silo
 

--- a/example/chat-app/ChatApp.Server/Clients/IChatClient.cs
+++ b/example/chat-app/ChatApp.Server/Clients/IChatClient.cs
@@ -1,4 +1,4 @@
-using ChatApp.GrainInterfaces.Model;
+using ChatApp.Server.Model;
 
 namespace ChatApp.Server.Clients;
 

--- a/example/chat-app/ChatApp.Server/Hubs/ChatHub.cs
+++ b/example/chat-app/ChatApp.Server/Hubs/ChatHub.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using ChatApp.GrainInterfaces;
 using ChatApp.GrainInterfaces.Model;
 using ChatApp.Server.Clients;
+using ChatApp.Server.Model;
 using Microsoft.AspNetCore.SignalR;
 
 namespace ChatApp.Server.Hubs;

--- a/example/chat-app/ChatApp.Server/Model/ChatHubModels.cs
+++ b/example/chat-app/ChatApp.Server/Model/ChatHubModels.cs
@@ -1,4 +1,4 @@
-namespace ChatApp.GrainInterfaces.Model;
+namespace ChatApp.Server.Model;
 
 [GenerateSerializer]
 public record JoinChatRequest(string ChatName);

--- a/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
@@ -50,6 +50,7 @@ namespace OrgnalR.Backplane.GrainAdaptors
                 messageCallback,
                 onSubscriptionEnd
             );
+
             var messageGrain = grainFactory.GetGrain<IAnonymousMessageGrain>(hubName);
             var handlerRef = grainFactory.CreateObjectReference<IAnonymousMessageObserver>(handler);
             anonymousObservers[handle.SubscriptionId] = (handler, handlerRef);

--- a/src/OrgnalR.Backplane.GrainAdaptors/OrleansMessageArgsSerializer.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/OrleansMessageArgsSerializer.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.ObjectPool;
+using OrgnalR.Core.Provider;
+using Orleans.Serialization;
+
+namespace OrgnalR.Backplane.GrainAdaptors;
+
+public class OrleansMessageArgsSerializer : IMessageArgsSerializer
+{
+    private readonly Serializer serializer;
+
+    public OrleansMessageArgsSerializer(Orleans.Serialization.Serializer serializer)
+    {
+        this.serializer = serializer;
+    }
+
+    public object?[] Deserialize(byte[] serialized)
+    {
+        return serializer.Deserialize<object?[]>(serialized);
+    }
+
+    public byte[] Serialize(object?[] args)
+    {
+        return serializer.SerializeToArray(args);
+    }
+}

--- a/src/OrgnalR.Core/Provider/IMessageArgsSerializer.cs
+++ b/src/OrgnalR.Core/Provider/IMessageArgsSerializer.cs
@@ -1,0 +1,8 @@
+namespace OrgnalR.Core.Provider;
+
+public interface IMessageArgsSerializer
+{
+    byte[] Serialize(object?[] args);
+
+    object?[] Deserialize(byte[] serialized);
+}

--- a/src/OrgnalR.Core/Provider/MethodMessage.cs
+++ b/src/OrgnalR.Core/Provider/MethodMessage.cs
@@ -3,5 +3,5 @@ using Orleans;
 namespace OrgnalR.Core.Provider
 {
     [GenerateSerializer]
-    public record MethodMessage(string MethodName, object?[] Args);
+    public record MethodMessage(string MethodName, byte[] SerializedArgs);
 }

--- a/src/OrgnalR.SignalR/Extensions.cs
+++ b/src/OrgnalR.SignalR/Extensions.cs
@@ -28,6 +28,7 @@ namespace OrgnalR.SignalR
         {
             // Will pull the grain factory from the registered services
             builder.Services.AddSingleton<IGrainFactoryProvider, GrainFactoryProvider>();
+            builder.Services.AddSingleton<IMessageArgsSerializer, OrleansMessageArgsSerializer>();
             builder.Services.AddSingleton<IActorProviderFactory, GrainActorProviderFactory>();
             builder.Services.AddSingleton(
                 typeof(IMessageObservable<>),
@@ -154,6 +155,7 @@ namespace OrgnalR.SignalR
                     services.GetRequiredService<IActorProviderFactory>(),
                     services.GetRequiredService<IMessageObservable<T>>(),
                     services.GetRequiredService<IMessageObserver<T>>(),
+                    services.GetRequiredService<IMessageArgsSerializer>(),
                     services.GetRequiredService<ILogger<OrgnalRHubLifetimeManager<T>>>()
                 );
             }

--- a/test/OrgnalR.Tests/Grains/RewindableMessageGrainTests.cs
+++ b/test/OrgnalR.Tests/Grains/RewindableMessageGrainTests.cs
@@ -54,14 +54,14 @@ public class RewindableMessageGrainTests
         var handle = await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget1", Array.Empty<object>())
+                new MethodMessage("TestTarget1", Array.Empty<byte>())
             )
         );
         var since = await grain.GetMessagesSinceAsync(handle);
         Assert.Empty(since);
         var secondMsg = new AnonymousMessage(
             new HashSet<string>(),
-            new MethodMessage("TestTarget2", new[] { "Message 2" })
+            new MethodMessage("TestTarget2", new byte[] { 1, 2, 3 })
         );
         var handle2 = await grain.PushMessageAsync(secondMsg);
         since = await grain.GetMessagesSinceAsync(handle2);
@@ -69,7 +69,10 @@ public class RewindableMessageGrainTests
         since = await grain.GetMessagesSinceAsync(handle);
         Assert.NotEmpty(since);
         Assert.Equal(handle2, since.Single().handle);
-        Assert.Equal(secondMsg.Payload.Args[0], since.Single().message.Payload.Args[0]);
+        Assert.Equal(
+            secondMsg.Payload.SerializedArgs,
+            since.Single().message.Payload.SerializedArgs
+        );
     }
 
     [Fact]
@@ -91,7 +94,7 @@ public class RewindableMessageGrainTests
                     grain.PushMessageAsync(
                         new AnonymousMessage(
                             new HashSet<string>(),
-                            new MethodMessage(i.ToString(), Array.Empty<object>())
+                            new MethodMessage(i.ToString(), Array.Empty<byte>())
                         )
                     )
             )
@@ -129,19 +132,19 @@ public class RewindableMessageGrainTests
         var handle = await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget1", Array.Empty<object>())
+                new MethodMessage("TestTarget1", Array.Empty<byte>())
             )
         );
         await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget2", Array.Empty<object>())
+                new MethodMessage("TestTarget2", Array.Empty<byte>())
             )
         );
         await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget3", Array.Empty<object>())
+                new MethodMessage("TestTarget3", Array.Empty<byte>())
             )
         );
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
@@ -163,7 +166,7 @@ public class RewindableMessageGrainTests
         var handle = await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget1", new object[0])
+                new MethodMessage("TestTarget1", Array.Empty<byte>())
             )
         );
         handle = new MessageHandle(handle.MessageId, Guid.NewGuid());
@@ -183,7 +186,7 @@ public class RewindableMessageGrainTests
         var handle = await grain.PushMessageAsync(
             new AnonymousMessage(
                 new HashSet<string>(),
-                new MethodMessage("TestTarget1", new object[0])
+                new MethodMessage("TestTarget1", Array.Empty<byte>())
             )
         );
         handle = new MessageHandle(handle.MessageId + 1, handle.MessageGroup);


### PR DESCRIPTION
This PR amends the [OrgnalRHubLifetimeManager](https://github.com/LiamMorrow/OrgnalR/compare/add-message-serializer?expand=1#diff-254b7280417dde5d3793aefca6e432b076831213aab2b5a18fd8f8b8935d909f) to serialize message payloads to byte arrays using the serializer provided by Orleans.

This allows the consumer to register their SignalR message types with orleans (using the GenerateSerializer attribute), without having to have them declared where the silo knows about them.