### PR TITLE
Wait for cluster client to be active

### DIFF
--- a/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
@@ -32,7 +32,9 @@ namespace OrgnalR.Backplane.GrainAdaptors
             this.hubName = hubName ?? throw new ArgumentNullException(nameof(hubName));
             this.grainFactory =
                 grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
-            this.grainProviderReadier = grainProviderReadier;
+            this.grainProviderReadier =
+                grainProviderReadier
+                ?? throw new ArgumentNullException(nameof(grainProviderReadier));
         }
 
         public async Task<SubscriptionHandle> SubscribeToAllAsync(

--- a/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/GrainMessageObservable.cs
@@ -3,9 +3,9 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using OrgnalR.Backplane.GrainInterfaces;
+using OrgnalR.Core;
 using OrgnalR.Core.Provider;
 using Orleans;
-using Orleans.Utilities;
 
 namespace OrgnalR.Backplane.GrainAdaptors
 {
@@ -13,28 +13,26 @@ namespace OrgnalR.Backplane.GrainAdaptors
     {
         private readonly string hubName;
         private readonly IGrainFactory grainFactory;
+        private readonly GrainProviderReadier grainProviderReadier;
         private readonly ConcurrentDictionary<
             Guid,
             (IAnonymousMessageObserver raw, IAnonymousMessageObserver obj)
-        > anonymousObservers =
-            new ConcurrentDictionary<
-                Guid,
-                (IAnonymousMessageObserver raw, IAnonymousMessageObserver obj)
-            >();
+        > anonymousObservers = new();
         private readonly ConcurrentDictionary<
             string,
             (IClientMessageObserver raw, IClientMessageObserver obj)
-        > clientObservers =
-            new ConcurrentDictionary<
-                string,
-                (IClientMessageObserver raw, IClientMessageObserver obj)
-            >();
+        > clientObservers = new();
 
-        public GrainMessageObservable(string hubName, IGrainFactory grainFactory)
+        public GrainMessageObservable(
+            string hubName,
+            IGrainFactory grainFactory,
+            GrainProviderReadier grainProviderReadier
+        )
         {
             this.hubName = hubName ?? throw new ArgumentNullException(nameof(hubName));
             this.grainFactory =
                 grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+            this.grainProviderReadier = grainProviderReadier;
         }
 
         public async Task<SubscriptionHandle> SubscribeToAllAsync(
@@ -44,6 +42,7 @@ namespace OrgnalR.Backplane.GrainAdaptors
             CancellationToken cancellationToken = default
         )
         {
+            await grainProviderReadier.ClusterClientReady.WithCancellation(cancellationToken);
             var handle = new SubscriptionHandle(Guid.NewGuid());
             var handler = new DelegateAnonymousMessageObserver(
                 handle,
@@ -63,6 +62,7 @@ namespace OrgnalR.Backplane.GrainAdaptors
             CancellationToken cancellationToken = default
         )
         {
+            await grainProviderReadier.ClusterClientReady.WithCancellation(cancellationToken);
             if (!anonymousObservers.TryRemove(subscriptionHandle.SubscriptionId, out var handler))
             {
                 return;
@@ -79,6 +79,7 @@ namespace OrgnalR.Backplane.GrainAdaptors
             CancellationToken cancellationToken = default
         )
         {
+            await grainProviderReadier.ClusterClientReady.WithCancellation(cancellationToken);
             var handler = new DelegateClientMessageObserver(
                 connectionId,
                 messageCallback,
@@ -98,6 +99,7 @@ namespace OrgnalR.Backplane.GrainAdaptors
             CancellationToken cancellationToken = default
         )
         {
+            await grainProviderReadier.ClusterClientReady.WithCancellation(cancellationToken);
             if (!clientObservers.TryRemove(connectionId, out var handler))
             {
                 return;

--- a/src/OrgnalR.Backplane.GrainAdaptors/GrainProviderReadier.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/GrainProviderReadier.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Orleans;
+
+namespace OrgnalR.Backplane.GrainAdaptors;
+
+public class GrainProviderReadier : ILifecycleParticipant<IClusterClientLifecycle>
+{
+    private readonly TaskCompletionSource clusterClientReady = new();
+    private readonly ILogger<GrainProviderReadier> logger;
+
+    public Task ClusterClientReady => clusterClientReady.Task;
+
+    public GrainProviderReadier(ILogger<GrainProviderReadier> logger)
+    {
+        this.logger = logger;
+    }
+
+    public void Participate(IClusterClientLifecycle observer)
+    {
+        logger.LogDebug("Participating in lifecycle");
+        observer.Subscribe<GrainProviderReadier>(
+            ServiceLifecycleStage.Active,
+            (_cancellation) =>
+            {
+                logger.LogDebug("ClusterClient ready");
+                clusterClientReady.TrySetResult();
+                return Task.CompletedTask;
+            }
+        );
+    }
+}

--- a/src/OrgnalR.Backplane.GrainAdaptors/GrainProviderReadier.cs
+++ b/src/OrgnalR.Backplane.GrainAdaptors/GrainProviderReadier.cs
@@ -14,7 +14,7 @@ public class GrainProviderReadier : ILifecycleParticipant<IClusterClientLifecycl
 
     public GrainProviderReadier(ILogger<GrainProviderReadier> logger)
     {
-        this.logger = logger;
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public void Participate(IClusterClientLifecycle observer)

--- a/src/OrgnalR.SignalR/OrgnalRHubLifetimeManager.cs
+++ b/src/OrgnalR.SignalR/OrgnalRHubLifetimeManager.cs
@@ -78,7 +78,6 @@ namespace OrgnalR.SignalR
                 messageArgsSerializer,
                 logger
             );
-            await Task.Delay(5000, cancellationToken);
             manager.allSubscriptionHandle = await messageObservable.SubscribeToAllAsync(
                 manager.OnAnonymousMessageReceived,
                 manager.OnAnonymousSubscriptionEnd,


### PR DESCRIPTION
We had an issue (#29) where the cluster client wasn't ready by the time we got an observable reference.  This caused a null reference exception.

We fixed it by adding a Task.Delay before subscribing.  This commit uses the built in lifecycle methods of orleans to expose a task which lets a consumer wait until it is ready before using it.

closes: #29 