### PR TITLE
Orleans upgraded to 7.1.2

### DIFF
--- a/example/chat-app/ChatApp.GrainInterfaces/ChatApp.GrainInterfaces.csproj
+++ b/example/chat-app/ChatApp.GrainInterfaces/ChatApp.GrainInterfaces.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
   </ItemGroup>
 
 </Project>

--- a/example/chat-app/ChatApp.Server/ChatApp.Server.csproj
+++ b/example/chat-app/ChatApp.Server/ChatApp.Server.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="7.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/chat-app/ChatApp.Silo/ChatApp.Silo.csproj
+++ b/example/chat-app/ChatApp.Silo/ChatApp.Silo.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="7.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/OrgnalR.Backplane.GrainAdaptors/OrgnalR.Backplane.GrainAdaptors.csproj
+++ b/src/OrgnalR.Backplane.GrainAdaptors/OrgnalR.Backplane.GrainAdaptors.csproj
@@ -10,7 +10,7 @@
         </Description>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OrgnalR.Backplane.GrainInterfaces\OrgnalR.Backplane.GrainInterfaces.csproj" />

--- a/src/OrgnalR.Backplane.GrainImplementations/OrgnalR.Backplane.GrainImplementations.csproj
+++ b/src/OrgnalR.Backplane.GrainImplementations/OrgnalR.Backplane.GrainImplementations.csproj
@@ -14,6 +14,6 @@
         <ProjectReference Include="..\OrgnalR.Core\OrgnalR.Core.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
     </ItemGroup>
 </Project>

--- a/src/OrgnalR.Backplane.GrainInterfaces/OrgnalR.Backplane.GrainInterfaces.csproj
+++ b/src/OrgnalR.Backplane.GrainInterfaces/OrgnalR.Backplane.GrainInterfaces.csproj
@@ -13,6 +13,6 @@
         <ProjectReference Include="..\OrgnalR.Core\OrgnalR.Core.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
     </ItemGroup>
 </Project>

--- a/src/OrgnalR.Core/OrgnalR.Core.csproj
+++ b/src/OrgnalR.Core/OrgnalR.Core.csproj
@@ -13,6 +13,6 @@
     <ItemGroup>
         <PackageReference Include="System.IO" Version="4.3.0" />
         <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.1.2" />
     </ItemGroup>
 </Project>

--- a/src/OrgnalR.OrleansSilo/OrgnalR.OrleansSilo.csproj
+++ b/src/OrgnalR.OrleansSilo/OrgnalR.OrleansSilo.csproj
@@ -15,6 +15,6 @@
         <ProjectReference Include="..\OrgnalR.Backplane.GrainAdaptors\OrgnalR.Backplane.GrainAdaptors.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Server" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Server" Version="7.1.2" />
     </ItemGroup>
 </Project>

--- a/src/OrgnalR.SignalR/OrgnalR.SignalR.csproj
+++ b/src/OrgnalR.SignalR/OrgnalR.SignalR.csproj
@@ -12,7 +12,7 @@
         <OutputType>Library</OutputType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Client" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.Client" Version="7.1.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\OrgnalR.Core\OrgnalR.Core.csproj" />

--- a/test/OrgnalR.Tests/OrgnalR.Tests.csproj
+++ b/test/OrgnalR.Tests/OrgnalR.Tests.csproj
@@ -12,7 +12,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.1.2" />
         <PackageReference Include="moq" Version="4.18.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
When I try to use OrgnalR with the latest Orleans version (7.1.2) I got this error:
![image](https://github.com/LiamMorrow/OrgnalR/assets/709446/81ac6cc0-9c62-4f2b-ba74-390683f85b89)
So I had to downgrade my app to use Orleans 7.0.0, which I think is not the bes option.

Thanks